### PR TITLE
Fix/workflow config

### DIFF
--- a/.github/workflows/deploy-main.yaml
+++ b/.github/workflows/deploy-main.yaml
@@ -4,13 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       env:
-        description: Target environment (main or dev)
+        description: Target environment (prod or dev)
         required: true
         type: choice
         options:
-          - main
+          - prod
           - dev
-        default: main
+        default: prod
       apply:
         description: Set true to run apply after plan
         required: true
@@ -27,16 +27,16 @@ concurrency:
 
 jobs:
   opentofu-infra:
-    name: 🪄 OpenTofu infra (main)
+    name: 🪄 OpenTofu infra (${{ inputs.env }})
     uses: ./.github/workflows/tf-plan-apply.yaml
     with:
       env: ${{ inputs.env }}
       apply: ${{ inputs.apply }}
-      cwd: deployments/main/0-infra
+      cwd: deployments/${{ inputs.env }}/0-infra
     secrets: inherit
 
   opentofu-services:
-    name: 🪄 OpenTofu services (main)
+    name: 🪄 OpenTofu services (${{ inputs.env }})
     needs:
       - opentofu-infra
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')
@@ -44,6 +44,6 @@ jobs:
     with:
       env: ${{ inputs.env }}
       apply: ${{ inputs.apply }}
-      cwd: deployments/main/1-services
+      cwd: deployments/${{ inputs.env }}/1-services
       infra_outputs: ${{ needs.opentofu-infra.outputs.tf_outputs }}
     secrets: inherit

--- a/.github/workflows/deploy-main.yaml
+++ b/.github/workflows/deploy-main.yaml
@@ -26,21 +26,24 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  tofu-infra:
-    name: 0-infra (${{ inputs.env }})
+  opentofu-infra:
+    name: 🪄 OpenTofu infra (main)
     uses: ./.github/workflows/tf-plan-apply.yaml
     with:
       env: ${{ inputs.env }}
       apply: ${{ inputs.apply }}
-      cwd: deployments/${{ inputs.env }}/0-infra
+      cwd: deployments/main/0-infra
     secrets: inherit
 
-  tofu-services:
-    name: 1-services (${{ inputs.env }})
-    needs: tofu-infra
+  opentofu-services:
+    name: 🪄 OpenTofu services (main)
+    needs:
+      - opentofu-infra
+    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     uses: ./.github/workflows/tf-plan-apply.yaml
     with:
       env: ${{ inputs.env }}
       apply: ${{ inputs.apply }}
-      cwd: deployments/${{ inputs.env }}/1-services
+      cwd: deployments/main/1-services
+      infra_outputs: ${{ needs.opentofu-infra.outputs.tf_outputs }}
     secrets: inherit

--- a/.github/workflows/merge-main.yaml
+++ b/.github/workflows/merge-main.yaml
@@ -21,7 +21,7 @@ jobs:
     name: 🔢 Get next semantic version
     runs-on: ubuntu-latest
     outputs:
-      next_version: ${{ steps.semantic.outputs.version }}
+      next_version: ${{ steps.semantic.outputs.new_release_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
     secrets: inherit
 
   opentofu-infra:
-    name: 🪄 OpenTofu infra (main)
+    name: 🪄 OpenTofu infra (prod)
     needs:
         - build-backend
         - build-frontend
@@ -81,18 +81,19 @@ jobs:
     with:
       env: prod
       apply: false
-      cwd: deployments/main/0-infra
+      cwd: deployments/prod/0-infra
     secrets: inherit
 
   opentofu-services:
-    name: 🪄 OpenTofu services (main)
+    name: 🪄 OpenTofu services (prod)
     needs:
       - opentofu-infra
+    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     uses: ./.github/workflows/tf-plan-apply.yaml
     with:
       env: prod
       apply: false
-      cwd: deployments/main/1-services
+      cwd: deployments/prod/1-services
       infra_outputs: ${{ needs.opentofu-infra.outputs.tf_outputs }}
     secrets: inherit
 

--- a/.github/workflows/tf-plan-apply.yaml
+++ b/.github/workflows/tf-plan-apply.yaml
@@ -135,7 +135,7 @@ jobs:
     - name: 🚀 Refresh
       if: ${{ !inputs.apply }}
       working-directory: ${{ inputs.cwd}}
-      run: tofu apply -refresh-only -auto-approve
+      run: tofu apply -refresh-only -auto-approve -var="github_token=${{ secrets.USER_GITHUB_TOKEN }}"
 
 
     - name: 📦 Export outputs

--- a/.github/workflows/tf-plan-apply.yaml
+++ b/.github/workflows/tf-plan-apply.yaml
@@ -132,6 +132,11 @@ jobs:
       working-directory: ${{ inputs.cwd}}
       run: tofu apply -auto-approve tfplan
 
+    - name: 🚀 Refresh
+      if: ${{ !inputs.apply }}
+      working-directory: ${{ inputs.cwd}}
+      run: tofu apply -refresh-only -auto-approve
+
 
     - name: 📦 Export outputs
       id: capture_outputs

--- a/deployments/dev/0-infra/terraform.tfvars
+++ b/deployments/dev/0-infra/terraform.tfvars
@@ -2,6 +2,7 @@
 project_id = "rubenschulze-sandbox"
 region     = "europe-west4"
 apis = [
+  "cloudresourcemanager.googleapis.com",
   "run.googleapis.com",             # Cloud Run
   "sqladmin.googleapis.com",        # Cloud SQL
   "container.googleapis.com",       # Container Registry


### PR DESCRIPTION
This pull request updates the deployment workflows to standardize environment naming, improve workflow reliability, and enhance infrastructure management. The main changes include renaming the "main" environment to "prod", updating job names and conditions, and adding a refresh step to the infrastructure workflow. Additionally, a required API was added to the development environment configuration.

**Workflow and Environment Naming Updates:**

* Changed all references and options from "main" to "prod" for the deployment target environment in `.github/workflows/deploy-main.yaml` and `.github/workflows/merge-main.yaml`, including job names, input descriptions, and deployment paths. [[1]](diffhunk://#diff-490ceef314576a167c0ca5d1b8c48c6c34eb1f02b71e3715264eac679bdf79c1L7-R13) [[2]](diffhunk://#diff-5f3bb1d24a11b3d527cecb38ed49597737d4bd42318c402d840d18992221a7b2L73-R73) [[3]](diffhunk://#diff-5f3bb1d24a11b3d527cecb38ed49597737d4bd42318c402d840d18992221a7b2L84-R96)

**Workflow Logic and Reliability Improvements:**

* Updated job dependencies and conditions for `opentofu-infra` and `opentofu-services` jobs to use new names and ensure jobs only run when previous jobs succeed, adding checks to prevent running on failure or cancellation. [[1]](diffhunk://#diff-490ceef314576a167c0ca5d1b8c48c6c34eb1f02b71e3715264eac679bdf79c1L29-R48) [[2]](diffhunk://#diff-5f3bb1d24a11b3d527cecb38ed49597737d4bd42318c402d840d18992221a7b2L84-R96)

**Infrastructure Workflow Enhancements:**

* Added a "Refresh" step to the `tf-plan-apply.yaml` workflow to run `tofu apply -refresh-only` when not applying changes, ensuring infrastructure state is up-to-date.

**Configuration Updates:**

* Added `cloudresourcemanager.googleapis.com` to the list of enabled APIs in `deployments/dev/0-infra/terraform.tfvars` for the dev environment.

**Minor Output Adjustment:**

* Updated the output variable name for the semantic versioning step in `.github/workflows/merge-main.yaml` to match the new output key from the action.