### PR TITLE
fix: fixed manual deployment workflow

### DIFF
--- a/.github/workflows/deploy-main.yaml
+++ b/.github/workflows/deploy-main.yaml
@@ -32,7 +32,7 @@ jobs:
     with:
       env: ${{ inputs.env }}
       apply: ${{ inputs.apply }}
-      cwd: deployments/main/0-infra
+      cwd: deployments/${{ inputs.env }}/0-infra
     secrets: inherit
 
   opentofu-services:

--- a/deployments/prod/1-services/terraform.tfvars
+++ b/deployments/prod/1-services/terraform.tfvars
@@ -6,4 +6,3 @@ embedding_size   = 768
 log_level        = "INFO"
 domain_url       = "swim-gen.com"
 outputs_location = "../0-config"
-version_tag      = "1.0.0"


### PR DESCRIPTION
This pull request makes a small update to the deployment workflow configuration, specifically making the infrastructure deployment path dynamic based on the environment. Additionally, there is a minor cleanup in the production service configuration.

Workflow improvements:

* Updated the `cwd` path in `.github/workflows/deploy-main.yaml` to use the environment variable, ensuring that deployments target the correct environment-specific infrastructure directory.

Configuration cleanup:

* Removed the unused `version_tag` variable from `deployments/prod/1-services/terraform.tfvars`.