### PR TITLE
feat: change cicd to comment based dev deploy

### DIFF
--- a/.github/workflows/backend-validate.yaml
+++ b/.github/workflows/backend-validate.yaml
@@ -9,7 +9,7 @@ on:
           description: Environment to setup for
           default: dev
   pull_request:
-    branches: [dev, main]
+    branches: [main]
     paths:
       - backend/**
       - .github/workflows/backend-build.yaml

--- a/.github/workflows/bff-validate.yaml
+++ b/.github/workflows/bff-validate.yaml
@@ -9,7 +9,7 @@ on:
           description: "Environment to setup for"
           default: dev
   pull_request:
-    branches: [dev, main]
+    branches: [main]
     paths:
       - "bff/**"
       - ".github/workflows/bff-build.yaml"

--- a/.github/workflows/build-and-deploy-dev.yaml
+++ b/.github/workflows/build-and-deploy-dev.yaml
@@ -1,12 +1,12 @@
 name: 🚀 Build & Deploy (dev)
 
 on:
-  push:
-    branches: [dev]
+  issue_comment:
+    types: [created]
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -14,8 +14,19 @@ permissions:
   contents: write # This is required for actions/checkout
 
 jobs:
+  opentofu-infra:
+    name: 🪄 OpenTofu infra (dev)
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '.deploy dev')
+    uses: ./.github/workflows/tf-plan-apply.yaml
+    with:
+      env: dev
+      apply: true
+      cwd: deployments/dev/0-infra
+    secrets: inherit
+
   detect-changes:
     name: 🔎 Detect service changes
+    needs: opentofu-infra
     runs-on: ubuntu-latest
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
@@ -25,10 +36,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.issue.pull_request.head.ref }}
           fetch-depth: 0
       - id: filter
         run: |
-          changed() { git diff --name-only origin/${{ github.ref_name }}~1 | grep -E "^$1/" >/dev/null && echo true || echo false; }
+          changed() { git diff --name-only origin/dev | grep -E "^$1/" >/dev/null && echo true || echo false; }
           echo "backend=$(changed backend)" >> $GITHUB_OUTPUT
           echo "frontend=$(changed frontend)" >> $GITHUB_OUTPUT
           echo "bff=$(changed bff)" >> $GITHUB_OUTPUT
@@ -66,25 +78,14 @@ jobs:
       env: dev
     secrets: inherit
 
-  opentofu-infra:
-    name: 🪄 OpenTofu infra (dev)
-    needs:
-      - build-backend
-      - build-frontend
-      - build-bff
-      - build-mcp
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
-    uses: ./.github/workflows/tf-plan-apply.yaml
-    with:
-      env: dev
-      apply: true
-      cwd: deployments/dev/0-infra
-    secrets: inherit
-
   opentofu-services:
     name: 🪄 OpenTofu services (dev)
     needs:
       - opentofu-infra
+      - build-backend
+      - build-frontend
+      - build-bff
+      - build-mcp
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     uses: ./.github/workflows/tf-plan-apply.yaml
     with:

--- a/.github/workflows/build-and-deploy-dev.yaml
+++ b/.github/workflows/build-and-deploy-dev.yaml
@@ -12,6 +12,7 @@ concurrency:
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: write # This is required for actions/checkout
+  issues: write # This is required for reacting to comments and posting comments
 
 jobs:
   opentofu-infra:
@@ -94,3 +95,36 @@ jobs:
       cwd: deployments/dev/1-services
       infra_outputs: ${{ needs.opentofu-infra.outputs.tf_outputs }}
     secrets: inherit
+
+  react-to-comment:
+    name: 👍 React to deploy comment
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '.deploy dev')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add reaction to comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1'
+            });
+
+  comment-on-completion:
+    name: 💬 Comment on deployment completion
+    needs: opentofu-services
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: 'Deployment to dev completed successfully! 🚀'
+            });

--- a/.github/workflows/frontend-validate.yaml
+++ b/.github/workflows/frontend-validate.yaml
@@ -9,7 +9,7 @@ on:
           description: "Environment to setup for"
           default: dev
   pull_request:
-    branches: [dev, main]
+    branches: [main]
     paths:
       - "frontend/**"
       - ".github/workflows/frontend-validate.yaml"

--- a/.github/workflows/mcp-validate.yaml
+++ b/.github/workflows/mcp-validate.yaml
@@ -9,7 +9,7 @@ on:
         description: "Environment to setup for"
         default: dev
   pull_request:
-    branches: [dev, main]
+    branches: [main]
     paths:
       - "mcp-server/**"
       - ".github/workflows/mcp-validate.yaml"

--- a/.github/workflows/merge-main.yaml
+++ b/.github/workflows/merge-main.yaml
@@ -17,8 +17,18 @@ env:
   TF_IN_AUTOMATION: true
 
 jobs:
+  opentofu-infra:
+    name: 🪄 OpenTofu infra (prod)
+    uses: ./.github/workflows/tf-plan-apply.yaml
+    with:
+      env: prod
+      apply: false
+      cwd: deployments/prod/0-infra
+    secrets: inherit
+
   get_version:
     name: 🔢 Get next semantic version
+    needs: opentofu-infra
     runs-on: ubuntu-latest
     outputs:
       next_version: ${{ steps.semantic.outputs.new_release_version }}
@@ -69,25 +79,14 @@ jobs:
       version: ${{ needs.get_version.outputs.next_version }}
     secrets: inherit
 
-  opentofu-infra:
-    name: 🪄 OpenTofu infra (prod)
-    needs:
-        - build-backend
-        - build-frontend
-        - build-bff
-        - build-mcp
-    if: always() && !cancelled() && (needs.build-backend.result != 'failure') && (needs.build-frontend.result != 'failure') && (needs.build-bff.result != 'failure') && (needs.build-mcp.result != 'failure')
-    uses: ./.github/workflows/tf-plan-apply.yaml
-    with:
-      env: prod
-      apply: false
-      cwd: deployments/prod/0-infra
-    secrets: inherit
-
   opentofu-services:
     name: 🪄 OpenTofu services (prod)
     needs:
       - opentofu-infra
+      - build-backend
+      - build-frontend
+      - build-bff
+      - build-mcp
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     uses: ./.github/workflows/tf-plan-apply.yaml
     with:


### PR DESCRIPTION
This pull request updates the CI/CD workflows for both development and production environments, focusing on improving deployment controls and infrastructure provisioning. The main changes include switching to issue comment triggers for development deployments, restructuring job dependencies, and clarifying the separation between infrastructure and service deployments.

**Workflow trigger and job restructuring:**

* The development workflow (`.github/workflows/build-and-deploy-dev.yaml`, previously `merge-dev.yaml`) now triggers on issue comments containing `.deploy dev` instead of direct pushes to the `dev` branch, enabling more controlled deployments.
* Added a dedicated `opentofu-infra` job for provisioning infrastructure before service builds in both development and production workflows, ensuring infrastructure is ready before deploying services. [[1]](diffhunk://#diff-66e84022827968f5ac1f1b2cd1013bfa76a44e93608116d3d64a1278b0d7bd4fL4-R29) [[2]](diffhunk://#diff-5f3bb1d24a11b3d527cecb38ed49597737d4bd42318c402d840d18992221a7b2R20-R31)
* Refactored the service deployment jobs (`opentofu-services`) to depend on the successful completion of both infrastructure provisioning and all build jobs, and removed redundant job definitions for clarity. [[1]](diffhunk://#diff-66e84022827968f5ac1f1b2cd1013bfa76a44e93608116d3d64a1278b0d7bd4fL69-L89) [[2]](diffhunk://#diff-5f3bb1d24a11b3d527cecb38ed49597737d4bd42318c402d840d18992221a7b2L72-L90)

**Deployment logic improvements:**

* Updated the concurrency group in the dev workflow to use the issue number when available, preventing overlapping deployments for the same issue.
* The `detect-changes` job in the dev workflow now checks out the correct pull request head and compares changes against the `dev` branch, improving accuracy in change detection.